### PR TITLE
Automaticaly hide submit text on small screens and show on big screens

### DIFF
--- a/index.css
+++ b/index.css
@@ -91,12 +91,20 @@ a {
   }
 }
 
-#submit {
-  float: right;
+.center-vertically {
+  display: flex;
+  align-items: center;
+}
+
+@media (max-width: 820px) {
+  #submit-text {
+    display: none;
+  }
 }
 
 #logo {
   padding: 6px 16px;
+  padding-right: 0px;
 }
 
 #logo * {

--- a/index.html
+++ b/index.html
@@ -15,14 +15,14 @@
     <input id="filter" type="text" placeholder="Filter" spellcheck="false" autocapitalize="off">
     <span id="count"></span>
   </span>
-  <span id="submit">
-    <a href="https://github.com/mwarning/chaos-sticker-collection">Submit New</a>
-  </span>
-  <span id="logo">
-    <a href="https://github.com/mwarning/chaos-sticker-collection">
+  <a class="center-vertically" id="submit" href="https://github.com/mwarning/chaos-sticker-collection">
+    <span id="logo">
       <img src="github-logo.png" alt="GitHub logo">
-    </a>
-  </span>
+    </span>
+    <span id="submit-text">
+      Submit New
+    </span>
+  </a>
 </div>
     <!-- Images Container -->
     <div id="imagesContainer"></div>


### PR DESCRIPTION
Fixes #19 

* Just designing for the point where the text would cause a wrap…
* Also put that right stuff into a flexbox, so the click/hitbox is bigger (you can also click inside of the area) and you don't need 2 a tags in your code
* Removed the padding to the right of the logo, so it fits more neatly near the text. (looks okay in "mobile" view, too)

## Without text

![grafik](https://github.com/mwarning/chaos-sticker-collection/assets/11966684/fdce2e85-bb19-46d6-866a-cf710b4509e8)

## With text
![grafik](https://github.com/mwarning/chaos-sticker-collection/assets/11966684/ec647250-2a10-49f2-b374-d11b824e212a)
